### PR TITLE
Implemented onRetryPressed method because it didn't exist

### DIFF
--- a/lib/core/App.js
+++ b/lib/core/App.js
@@ -52,6 +52,10 @@ class App extends Component {
     return (<Screen {...props} />)
   }
 
+  onRetryPressed(){
+   this.props.retrieveUser();
+ }
+
   renderError() {
       return (<View>
         <Text style={styles.error}>


### PR DESCRIPTION
If the app couldn't retrieve the user there would be a problem because this method didn't exist if it tried to show us the retry button